### PR TITLE
form on NewMinion page now smoothly scales down to fill the screen.

### DIFF
--- a/src/views/NewMinion.vue
+++ b/src/views/NewMinion.vue
@@ -10,7 +10,7 @@
       </v-col>
     </v-row>
     <v-row align="center" justify="center">
-      <v-col cols="5">
+      <v-col xs="8" style="max-width: 500px">
         <v-form ref="form" v-model="valid" lazy-validation>
           <v-text-field
             v-model="target"


### PR DESCRIPTION
I've bumped up the number of columns which the new minion form runs over so that the form fills more of the screen at small sizes. To keep consistency with current behaviour on desktop, I've added a maximum width for the form resulting in a similar look.

closes #25 

![Screenshot_2020-05-08_19-07-57](https://user-images.githubusercontent.com/15848336/81435522-f2398d00-915f-11ea-8b9d-20a94df41a05.png)

![Screenshot_2020-05-08_19-08-14](https://user-images.githubusercontent.com/15848336/81435525-f2d22380-915f-11ea-84e2-51db574c4e2b.png)
