### PR TITLE
Change tabs to Vuetify component

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "vue": "^2.6.11",
     "vue-apollo": "^3.0.3",
     "vue-class-component": "^7.2.2",
-    "vue-nav-tabs": "^0.5.7",
     "vue-property-decorator": "^8.3.0",
     "vue-router": "^3.1.5",
     "vuetify": "^2.2.11",

--- a/src/views/Ens.vue
+++ b/src/views/Ens.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-container class="fill-height" fluid>
+  <v-container fluid>
     <v-row align="center" justify="center">
       <v-col cols="5">
         <v-img
@@ -10,8 +10,19 @@
       </v-col>
     </v-row>
     <v-row v-if="domainItems.length" align="center" justify="center">
-      <vue-tabs style="width: 400px; min-width: 300px;">
-        <v-tab title="Register">
+      <v-tabs
+        dark
+        fixed-tabs
+        v-model="tabs"
+        style="width:400px; min-width:300px; flex:none"
+      >
+        <v-tab>Register</v-tab>
+        <v-tab>Assigned Subdomains</v-tab>
+      </v-tabs>
+    </v-row>
+    <v-row v-if="domainItems.length" align="center" justify="center">
+      <v-tabs-items v-model="tabs" style="width:400px; min-width:300px">
+        <v-tab-item>
           <v-col xs="8">
             <v-form ref="form" v-model="valid" lazy-validation>
               <v-select
@@ -36,22 +47,23 @@
               </v-btn>
             </v-form>
           </v-col>
-        </v-tab>
-        <v-tab title="Assigned Subdomains" style="margin-top: 20px">
-          <template v-for="(subdomain) in processedSubdomains">
-            <p :key="subdomain.name">
+        </v-tab-item>
+        <v-tab-item>
+          <template v-for="subdomain in processedSubdomains">
+            <p :key="subdomain.name" style="margin:0 5px 16px">
               <b>{{ subdomain.name }}:</b> {{ subdomain.owner }}
             </p>
           </template>
-        </v-tab>
-      </vue-tabs>
+        </v-tab-item>
+      </v-tabs-items>
     </v-row>
 
     <v-row v-else align="center" justify="center">
       <v-col cols="5">
         <h1>ENS Subdomain Registrar</h1>
         <p>
-          Subdomains can be requested after configuring a domain in the Minion Subdomain Registrar contract.
+          Subdomains can be requested after configuring a domain in the Minion
+          Subdomain Registrar contract.
         </p>
       </v-col>
     </v-row>
@@ -59,71 +71,74 @@
 </template>
 
 <script>
-  import { VueTabs, VTab } from "vue-nav-tabs";
-  import "vue-nav-tabs/themes/vue-tabs.css";
-  export default {
-    props: {
-      domains: Array,
-      subdomains: Array,
+export default {
+  props: {
+    domains: Array,
+    subdomains: Array
+  },
+  computed: {
+    domainItems: function() {
+      return this.domains.map(d => `${d.domain}.eth`);
     },
-    components: { VueTabs, VTab },
-    computed: {
-      domainItems: function () {
-        return this.domains.map(d => `${d.domain}.eth`)
-      },
-      processedSubdomains: function () {
-        return this.subdomains.map(s => {
-          const domainName = this.domains.find(d => d.label === s.label).domain
-          const subdomainName = `${s.subdomain}.${domainName}.eth`
-          return {
-            name: subdomainName,
-            owner: s.owner
-          }
-        })
-      }
-    },
-    data: () => ({
-      domain: "",
-      subdomain: "",
-      subdomainItems: [],
-      subdomainRules: [
-        v => !!v || "Subdomain is required",
-        v => (v && !v.includes('.') && !v.includes(' ')) || "Subdomain must not contain periods or spaces"
-      ],
-      owner: "",
-      ownerRules: [
-        v => !!v || "Owner is required",
-        v => (v && /^(0x){1}[0-9a-fA-F]{40}$/i.test(v)) || "Must be a valid address", // can use web3 checksum
-        v => (v && v !== "0x0000000000000000000000000000000000000000") || "Owner cannot be a null address"
-      ],
-      valid: false
-    }),
-    methods: {
-      chooseDomain: function (item) {
-        this.domain = item.replace('.eth', '')
-        const currentDomain = this.domains.find(d => d.domain === this.domain)
-        this.subdomainItems = this.subdomains
-                     .filter(s => s.label === currentDomain.label)
-                     .map(s => s.subdomain)
-      },
-      submit() {
-        if (!this.valid) {
-          alert("Invalid Inputs");
-          return false;
-        }
-
-        if (this.subdomainItems.includes(this.subdomain)) {
-          alert("Subdomain already registered")
-          return false;
-        }
-
-        const request = {
-          domain: this.domain,
-          subdomain: this.subdomain,
-          owner: this.owner
-        }
-        this.$emit("registered", request);
-      }
+    processedSubdomains: function() {
+      return this.subdomains.map(s => {
+        const domainName = this.domains.find(d => d.label === s.label).domain;
+        const subdomainName = `${s.subdomain}.${domainName}.eth`;
+        return {
+          name: subdomainName,
+          owner: s.owner
+        };
+      });
     }
-  };
+  },
+  data: () => ({
+    domain: "",
+    subdomain: "",
+    subdomainItems: [],
+    subdomainRules: [
+      v => !!v || "Subdomain is required",
+      v =>
+        (v && !v.includes(".") && !v.includes(" ")) ||
+        "Subdomain must not contain periods or spaces"
+    ],
+    owner: "",
+    ownerRules: [
+      v => !!v || "Owner is required",
+      v =>
+        (v && /^(0x){1}[0-9a-fA-F]{40}$/i.test(v)) || "Must be a valid address", // can use web3 checksum
+      v =>
+        (v && v !== "0x0000000000000000000000000000000000000000") ||
+        "Owner cannot be a null address"
+    ],
+    tabs: null,
+    valid: false
+  }),
+  methods: {
+    chooseDomain: function(item) {
+      this.domain = item.replace(".eth", "");
+      const currentDomain = this.domains.find(d => d.domain === this.domain);
+      this.subdomainItems = this.subdomains
+        .filter(s => s.label === currentDomain.label)
+        .map(s => s.subdomain);
+    },
+    submit() {
+      if (!this.valid) {
+        alert("Invalid Inputs");
+        return false;
+      }
+
+      if (this.subdomainItems.includes(this.subdomain)) {
+        alert("Subdomain already registered");
+        return false;
+      }
+
+      const request = {
+        domain: this.domain,
+        subdomain: this.subdomain,
+        owner: this.owner
+      };
+      this.$emit("registered", request);
+    }
+  }
+};
 </script>

--- a/src/views/NewMinion.vue
+++ b/src/views/NewMinion.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-container class="fill-height" fluid>
+  <v-container fluid>
     <v-row align="center" justify="center">
       <v-col cols="5">
         <v-img
@@ -10,8 +10,19 @@
       </v-col>
     </v-row>
     <v-row align="center" justify="center">
-      <vue-tabs style="width: 400px; min-width: 300px;">
-        <v-tab title="ABI Selector">
+      <v-tabs
+        dark
+        fixed-tabs
+        v-model="tabs"
+        style="width:400px; min-width:300px; flex:none"
+      >
+        <v-tab>ABI Selector</v-tab>
+        <v-tab>Raw Bytes</v-tab>
+      </v-tabs>
+    </v-row>
+    <v-row align="center" justify="center">
+      <v-tabs-items v-model="tabs" style="width:400px; min-width:300px">
+        <v-tab-item>
           <v-col xs="8">
             <v-form ref="form" v-model="valid" lazy-validation>
               <v-text-field
@@ -69,8 +80,8 @@
               </v-btn>
             </v-form>
           </v-col>
-        </v-tab>
-        <v-tab title="Raw Bytes">
+        </v-tab-item>
+        <v-tab-item>
           <v-col xs="8">
             <v-form ref="form" v-model="valid" lazy-validation>
               <v-text-field
@@ -109,23 +120,21 @@
               </v-btn>
             </v-form>
           </v-col>
-        </v-tab>
-      </vue-tabs>
+        </v-tab-item>
+      </v-tabs-items>
     </v-row>
   </v-container>
 </template>
 <script>
-import { VueTabs, VTab } from "vue-nav-tabs";
-import "vue-nav-tabs/themes/vue-tabs.css";
 export default {
   props: {
     overlay: String,
     minions: Array,
     web3: Object
   },
-  components: { VueTabs, VTab },
   data: () => ({
     valid: false,
+    tabs: null,
     target: "",
     targetRules: [
       v => !!v || "Target is required",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14651,11 +14651,6 @@ vue-loader@^15.8.3:
     vue-hot-reload-api "^2.3.0"
     vue-style-loader "^4.1.0"
 
-vue-nav-tabs@^0.5.7:
-  version "0.5.7"
-  resolved "https://registry.yarnpkg.com/vue-nav-tabs/-/vue-nav-tabs-0.5.7.tgz#f9b8c410b43d9af1d92be6454f295af10c884e4a"
-  integrity sha512-Oqq7qnb0/JPAVSqM0haQ9TdEZaTbQq20TVn5ZCmBOu8m9qju9bI8cDdtWGHXSiMkpmhzsT83ybRb7S/+UYXRsw==
-
 vue-property-decorator@^8.3.0:
   version "8.4.0"
   resolved "https://registry.yarnpkg.com/vue-property-decorator/-/vue-property-decorator-8.4.0.tgz#f4e641f84ca51a7b4721e236392a1efbb6eac00b"


### PR DESCRIPTION
This PR removes the `vue-nav-tabs` dependency and uses Vuetify tab component instead

Screenshots

![image](https://user-images.githubusercontent.com/926341/85826352-0eae7a80-b74a-11ea-86ab-f495b1acca90.png)

![image](https://user-images.githubusercontent.com/926341/85826394-20901d80-b74a-11ea-9bcc-96337c917bcf.png)


Fixes #55 