### PR TITLE
add a way to call parent dao methods

### DIFF
--- a/contracts/Minion.sol
+++ b/contracts/Minion.sol
@@ -37,37 +37,6 @@ contract Minion {
         require(action.proposer == msg.sender, "Minion::Must be proposer");
         moloch.cancelProposal(_proposalId);
     }
-    
-    function doParentProposal(
-        uint256 _tributeOffered,
-        address _tributeToken,
-        uint256 _paymentRequested,
-        address _paymentToken,
-        string memory _details
-        ) 
-        public
-        returns (uint256)
-        {
-        uint256 shares;
-        (,shares,,,,) = moloch.members(msg.sender);
-        require(shares > 0, "Minion::Not a current dao member");
-        //TODO details could be built using MINION_ACTION_DETAILS
-        //TODO any other requires
-        //TODO should we allow shares or LOOT?
-        //TODO some event
-        
-        uint256 proposalId = moloch.submitProposal(
-            address(this),
-            0,
-            0,
-            _tributeOffered,
-            _tributeToken,
-            _paymentRequested,
-            _paymentToken,
-            _details
-        );
-        return proposalId;
-    }
 
     function proposeAction(
         address _actionTo,

--- a/contracts/Minion.sol
+++ b/contracts/Minion.sol
@@ -30,6 +30,44 @@ contract Minion {
     function doWithdraw(address _token, uint256 _amount) public {
         moloch.withdrawBalance(_token, _amount);
     }
+    
+    function doCancel(uint256 _proposalId) public {
+        Action memory action = actions[_proposalId];
+        require(!action.executed, "Minion::action executed");
+        require(action.proposer == msg.sender, "Minion::Must be proposer");
+        moloch.cancelProposal(_proposalId);
+    }
+    
+    function doParentProposal(
+        uint256 _tributeOffered,
+        address _tributeToken,
+        uint256 _paymentRequested,
+        address _paymentToken,
+        string memory _details
+        ) 
+        public
+        returns (uint256)
+        {
+        uint256 shares;
+        (,shares,,,,) = moloch.members(msg.sender);
+        require(shares > 0, "Minion::Not a current dao member");
+        //TODO details could be built using MINION_ACTION_DETAILS
+        //TODO any other requires
+        //TODO should we allow shares or LOOT?
+        //TODO some event
+        
+        uint256 proposalId = moloch.submitProposal(
+            address(this),
+            0,
+            0,
+            _tributeOffered,
+            _tributeToken,
+            _paymentRequested,
+            _paymentToken,
+            _details
+        );
+        return proposalId;
+    }
 
     function proposeAction(
         address _actionTo,

--- a/contracts/Minion.sol
+++ b/contracts/Minion.sol
@@ -15,6 +15,7 @@ contract Minion {
         address to;
         address proposer;
         bool executed;
+        bool cancelled;
         bytes data;
     }
 
@@ -34,8 +35,13 @@ contract Minion {
     function doCancel(uint256 _proposalId) public {
         Action memory action = actions[_proposalId];
         require(!action.executed, "Minion::action executed");
+        require(!action.cancelled, "Minion::action cancelled");
         require(action.proposer == msg.sender, "Minion::Must be proposer");
+        bool[6] memory flags = moloch.getProposalFlags(_proposalId);
+        require(!flags[0], "Minion::proposal already sponsored");
+        require(!flags[3], "Minion::proposal already cancelled");
         moloch.cancelProposal(_proposalId);
+        action.cancelled = true;
     }
 
     function proposeAction(
@@ -69,6 +75,7 @@ contract Minion {
             to: _actionTo,
             proposer: msg.sender,
             executed: false,
+            cancelled: false,
             data: _actionData
         });
 


### PR DESCRIPTION
THis adds 
doCancel 
allows the submiter to cancel a proposal if it has not been sponsored 

doParentProposal
allow a proposal to go stright to the doa so you do not have to make a proposal to make a proposal